### PR TITLE
Uses John Hopkins CSSE Data for US

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Notice that most countries follow a similar straight line path, indicating that 
 
 ## Credits
 
-This interactive pulls data on COVID-19 provided by [Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19) and <a href="https://github.com/nytimes/covid-19-data">NYTimes</a>. Huge thanks to them for making this invaluable data source publicly available.
+This interactive pulls data on COVID-19 provided by [Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19). Huge thanks to them for making this invaluable data source publicly available.
 
 Created by [Aatish Bhatia](https://aatishb.com/) in collaboration with [Henry Reich](https://www.youtube.com/user/minutephysics).
 
@@ -62,5 +62,5 @@ If you would like to participate or contribute, please read our [Contributor's G
 
 Code in this repository which is not otherwise licensed is licensed under the MIT License; see [LICENSE.txt](LICENSE.txt) for complete text.
 
-This repository pulls data from [2019 Novel Coronavirus COVID-19 (2019-nCoV) Data Repository by Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19) and [New York Times Coronavirus (Covid-19) Data in the United States](https://github.com/nytimes/covid-19-data#license-and-attribution). Please consult these repositories for terms of use on the data.
+This repository pulls data from [2019 Novel Coronavirus COVID-19 (2019-nCoV) Data Repository by Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19). Please consult these repositories for terms of use on the data.
 

--- a/index.html
+++ b/index.html
@@ -87,8 +87,7 @@
         <div v-if="!firstLoad && covidData.length == 0" id="nodata"><span>Not enough data for these parameters.</span></div>
 
         <div id="footer">
-          Created by <a href="https://aatishb.com/">Aatish Bhatia</a> in collaboration with <a href="https://www.youtube.com/user/minutephysics">Minute Physics</a> &middot; World data provided by <a href="https://github.com/CSSEGISandData/COVID-19">Johns Hopkins University</a> &middot; US state data provided by <a href="https://github.com/nytimes/covid-19-data">NYTimes</a> &middot; Shortcuts: +/- for daily changes, space to play/pause &middot; <a href="https://github.com/aatishb/covidtrends#credits">Credits & Source</a> &middot; <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html">Stay safe!</a>
-        </div>
+          Created by <a href="https://aatishb.com/">Aatish Bhatia</a> in collaboration with <a href="https://www.youtube.com/user/minutephysics">Minute Physics</a> &middot; Data provided by <a href="https://github.com/CSSEGISandData/COVID-19">Johns Hopkins University</a> &middot; Shortcuts: +/- for daily changes, space to play/pause &middot; <a href="https://github.com/aatishb/covidtrends#credits">Credits & Source</a> &middot; <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html">Stay safe!</a> </div>
 
       </div>
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -477,9 +477,15 @@ let app = new Vue({
         }
         Plotly.d3.csv(url, (data) => this.processData(data, selectedRegion, updateSelectedCountries));
       } else { // selectedRegion == 'US'
-        const type = (selectedData == 'Reported Deaths') ? 'deaths' : 'cases'
-        const url = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv';
-        Plotly.d3.csv(url, (data) => this.processData(this.preprocessNYTData(data, type), selectedRegion, updateSelectedCountries));
+        let url;
+        if (selectedData == 'Confirmed Cases') {
+         url = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_US.csv';
+        } else if (selectedData == 'Reported Deaths') {
+         url = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_US.csv';
+        } else {
+          return;
+        }
+        Plotly.d3.csv(url, (data) => this.processData(this.preprocessUSData(data), selectedRegion, updateSelectedCountries));
       }
     },
 
@@ -603,18 +609,21 @@ let app = new Vue({
 
     },
 
-    preprocessNYTData(data, type) {
-      let recastData = {};
-      data.forEach(e => {
-        let st = recastData[e.state]  = (recastData[e.state] || {'Province/State': e.state, 'Country/Region': 'US', 'Lat': null, 'Long': null});
-        st[fixNYTDate(e.date)] = parseInt(e[type]);
+    preprocessUSData(data) {
+      let result = {};
+      data.forEach(record => {
+        let region = record.Province_State
+        let temp = (result[region] || {'Province/State': region, 'Country/Region': 'US', 'Lat': null, 'Long': null})
+        Object.keys(record).forEach(key => {
+          // if they key starts with a digit we assume it is a date
+          if (/^\d/.test(key)) {
+            // each record is a county so we sum them up to get the state wide total
+            temp[key] = (temp[key] || 0) + parseInt(record[key])
+          }
+        });
+        result[region] = temp
       });
-      return Object.values(recastData);
-
-      function fixNYTDate(date) {
-        let tmp = date.split('-');
-        return `${tmp[1]}/${tmp[2]}/${tmp[0].substr(2)}`;
-      }
+      return Object.values(result);
     },
 
     play() {
@@ -770,7 +779,7 @@ let app = new Vue({
           return 'Countries';
         case 'Australia':
         case 'US':
-          return 'States';
+          return 'States and Territories';
         case 'China':
           return 'Provinces';
         case 'Canada':


### PR DESCRIPTION
The NYT data [methodology][1] differs from from the John Hopkins
methodology.

This change attempts to ensure consistency between the world data and
the US data by using the John Hopkins CSSE data set for both.

[1]: https://github.com/nytimes/covid-19-data#methodology-and-definitions