### PR TITLE
Tweak country name position

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -105,7 +105,7 @@ Vue.component('graph', {
         name: e.country,
         mode: 'markers+text',
         legendgroup: i,
-        textposition: 'top left',
+        textposition: 'center right',
         marker: {
           size: 6,
           color: 'rgba(254, 52, 110, 1)'


### PR DESCRIPTION
Currently a country name frequently overdrawn by other countries line because
a usual trend is to slower a growth rate over time. By moving labels after its
line makes the probability of overdraw smaller and overall readability higher.